### PR TITLE
Fixed VKUser object not getting created due to JSON body including a "data" parent dictionary

### DIFF
--- a/Classes/Model/VKObjectBuilder.m
+++ b/Classes/Model/VKObjectBuilder.m
@@ -28,9 +28,9 @@
 {
     NSError *error = nil;
 
-    if (JSON[@"bio"]) {
+    if (JSON[@"data"][@"bio"]) {
         //Object type is VKUser
-        id model = [MTLJSONAdapter modelOfClass:[VKUser class] fromJSONDictionary:JSON error:&error];
+        id model = [MTLJSONAdapter modelOfClass:[VKUser class] fromJSONDictionary:JSON[@"data"] error:&error];
         
         if (!error)
         {

--- a/Classes/Networking/VKClient+Authentication.m
+++ b/Classes/Networking/VKClient+Authentication.m
@@ -80,6 +80,8 @@
     
     return [self userWithUsername:username completion:^(id object, NSError *error) {
         self.currentUser = object;
+        if (completion)
+            completion(error);
     }];
 }
 
@@ -108,7 +110,9 @@
 }
 
 - (BOOL)isSignedIn {
-    return true;
+    if (self.currentUser)
+        return true;
+    return false;
 }
 
 - (void)signOut {


### PR DESCRIPTION
The JSON response looks like this:

    {"success":true,"data":{"userName":"nuudles","registrationDate":"2015-07-04T14:44:07.257Z","bio":"Aww snap, this user did not yet write their bio. If they did, it would show up here, you know.","profilePicture":"https://fakevout.azurewebsites.net/Graphics/thumb-placeholder.png","commentPoints":{"sum":0,"upCount":0,"downCount":0},"submissionPoints":{"sum":0,"upCount":0,"downCount":0},"commentVoting":{"sum":0,"upCount":0,"downCount":0},"submissionVoting":{"sum":0,"upCount":0,"downCount":0},"badges":[]}}

With a "success" and "data" field.