### PR TITLE
Change the default VKVoteStatus value to VKVoteStatusNone

### DIFF
--- a/Classes/Model/VKCountable.h
+++ b/Classes/Model/VKCountable.h
@@ -1,0 +1,28 @@
+//
+//  VKCountable.h
+//  Pods
+//
+//  Created by Christopher Luu on 7/9/15.
+//
+//
+
+#import <Mantle/Mantle.h>
+
+@interface VKCountable : MTLModel <MTLJSONSerializing>
+
+/**
+ The total number of upvotes.
+ */
+@property (nonatomic, assign, readonly) NSNumber* upCount;
+
+/**
+ The total number of downvotes.
+ */
+@property (nonatomic, assign, readonly) NSNumber* downCount;
+
+/**
+ The total sum.
+ */
+@property (nonatomic, assign, readonly) NSNumber* sum;
+
+@end

--- a/Classes/Model/VKCountable.m
+++ b/Classes/Model/VKCountable.m
@@ -1,0 +1,22 @@
+//
+//  VKCountable.m
+//  Pods
+//
+//  Created by Christopher Luu on 7/9/15.
+//
+//
+
+#import "VKCountable.h"
+
+@implementation VKCountable
+
++ (NSDictionary *)JSONKeyPathsByPropertyKey
+{
+    return @{
+             @"sum": @"sum",
+             @"upCount": @"upCount",
+             @"downCount": @"downCount",
+             };
+}
+
+@end

--- a/Classes/Model/VKUser.h
+++ b/Classes/Model/VKUser.h
@@ -7,6 +7,7 @@
 //
 
 #import <Mantle/Mantle.h>
+#import "VKCountable.h"
 
 @interface VKUser : MTLModel <MTLJSONSerializing>
 
@@ -29,5 +30,30 @@
  The badges the user has accumulated
  */
 @property (nonatomic, strong, readonly) NSArray *badges;
+
+/**
+ The date that the user registered
+ */
+@property (nonatomic, strong, readonly) NSDate *registrationDate;
+
+/**
+ The point count for the users' comments.
+ */
+@property (nonatomic, strong, readonly) VKCountable *commentPoints;
+
+/**
+ The point count for the users' submissions.
+ */
+@property (nonatomic, strong, readonly) VKCountable *submissionPoints;
+
+/**
+ The count for the users' comment voting.
+ */
+@property (nonatomic, strong, readonly) VKCountable *commentVoting;
+
+/**
+ The count for the users' submission voting.
+ */
+@property (nonatomic, strong, readonly) VKCountable *submissionVoting;
 
 @end

--- a/Classes/Model/VKUser.m
+++ b/Classes/Model/VKUser.m
@@ -8,6 +8,7 @@
 //
 
 #import "VKUser.h"
+#import "VKCountable.h"
 
 @implementation VKUser
 
@@ -29,6 +30,22 @@
 
 
 #pragma mark - MTLModel
+
++ (NSValueTransformer *)commentPointsJSONTransformer {
+    return [MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClass:VKCountable.class];
+}
+
++ (NSValueTransformer *)submissionPointsJSONTransformer {
+    return [MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClass:VKCountable.class];
+}
+
++ (NSValueTransformer *)commentVotingJSONTransformer {
+    return [MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClass:VKCountable.class];
+}
+
++ (NSValueTransformer *)submissionVotingJSONTransformer {
+    return [MTLValueTransformer mtl_JSONDictionaryTransformerWithModelClass:VKCountable.class];
+}
 
 + (NSValueTransformer *)registrationDateJSONTransformer {
     NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];

--- a/Classes/Model/VKUser.m
+++ b/Classes/Model/VKUser.m
@@ -18,9 +18,27 @@
              @"username": @"userName",
              @"bio": @"bio",
              @"profilePicture": @"profilePicture",
-             @"badges": @"badges"
+             @"badges": @"badges",
+             @"registrationDate": @"registrationDate",
+             @"commentPoints": @"commentPoints",
+             @"submissionPoints": @"submissionPoints",
+             @"commentVoting": @"commentVoting",
+             @"submissionVoting": @"submissionVoting"
              };
 }
 
+
+#pragma mark - MTLModel
+
++ (NSValueTransformer *)registrationDateJSONTransformer {
+    NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
+
+    return [MTLValueTransformer transformerUsingForwardBlock:^id(NSString *dateString, BOOL *success, NSError *__autoreleasing *error) {
+        return [dateFormatter dateFromString:dateString];
+    }];
+
+    return nil;
+}
 
 @end

--- a/Classes/Model/VKVotable.h
+++ b/Classes/Model/VKVotable.h
@@ -9,9 +9,9 @@
 #import "VKCreated.h"
 
 typedef NS_ENUM(NSUInteger, VKVoteStatus) {
+    VKVoteStatusNone,
     VKVoteStatusUpvoted,
-    VKVoteStatusDownvoted,
-    VKVoteStatusNone
+    VKVoteStatusDownvoted
 };
 
 @interface VKVotable : VKCreated


### PR DESCRIPTION
This is necessary because unvoted items don't send a "voteValue" field so the voteStatusJSONTransformer is never called