### PR TITLE
Move everything off the main queue

### DIFF
--- a/Classes/Model/VKCountable.h
+++ b/Classes/Model/VKCountable.h
@@ -13,16 +13,16 @@
 /**
  The total number of upvotes.
  */
-@property (nonatomic, assign, readonly) NSNumber* upCount;
+@property (nonatomic, strong, readonly) NSNumber* upCount;
 
 /**
  The total number of downvotes.
  */
-@property (nonatomic, assign, readonly) NSNumber* downCount;
+@property (nonatomic, strong, readonly) NSNumber* downCount;
 
 /**
  The total sum.
  */
-@property (nonatomic, assign, readonly) NSNumber* sum;
+@property (nonatomic, strong, readonly) NSNumber* sum;
 
 @end

--- a/Classes/Model/VKCountable.h
+++ b/Classes/Model/VKCountable.h
@@ -13,16 +13,16 @@
 /**
  The total number of upvotes.
  */
-@property (nonatomic, strong, readonly) NSNumber* upCount;
+@property (nonatomic, copy, readonly) NSNumber* upCount;
 
 /**
  The total number of downvotes.
  */
-@property (nonatomic, strong, readonly) NSNumber* downCount;
+@property (nonatomic, copy, readonly) NSNumber* downCount;
 
 /**
  The total sum.
  */
-@property (nonatomic, strong, readonly) NSNumber* sum;
+@property (nonatomic, copy, readonly) NSNumber* sum;
 
 @end

--- a/Classes/Networking/VKClient+Comments.h
+++ b/Classes/Networking/VKClient+Comments.h
@@ -24,7 +24,7 @@
  @param searchOptions The search options specifying the order of the response
  @return The NSURLSessionDataTask for the request.
  */
-- (NSURLSessionDataTask *)commentsForSubmission:(VKSubmission *)submission searchOptions:(VKSearchOptions*)searchOptions completion:(VKArrayCompletionBlock)completion;
+- (NSURLSessionDataTask *)commentsForSubmission:(VKSubmission *)submission searchOptions:(VKSearchOptions*)searchOptions completion:(VKListingCompletionBlock)completion;
 
 /**
  Gets all comments for a submision. Defaults to VKCommentSortTop sort order.
@@ -35,7 +35,7 @@
  @param completion An optional block to be executed upon request completion. It takes two arguments: an array of VKComments and any error that occurred.
  @return The NSURLSessionDataTask for the request.
  */
-- (NSURLSessionDataTask *)commentsForSubmissionWithIdentifier:(NSNumber *)submissionIdentifier withSubverse:(NSString*)subverse searchOptions:(VKSearchOptions*)searchOptions completion:(VKArrayCompletionBlock)completion;
+- (NSURLSessionDataTask *)commentsForSubmissionWithIdentifier:(NSNumber *)submissionIdentifier withSubverse:(NSString*)subverse searchOptions:(VKSearchOptions*)searchOptions completion:(VKListingCompletionBlock)completion;
 
 
 #pragma mark - Submitting Comments

--- a/Classes/Networking/VKClient+Comments.m
+++ b/Classes/Networking/VKClient+Comments.m
@@ -13,13 +13,13 @@
 
 #pragma mark - Getting Comments
 
-- (NSURLSessionDataTask *)commentsForSubmission:(VKSubmission *)submission searchOptions:(VKSearchOptions*)searchOptions completion:(VKArrayCompletionBlock)completion {
+- (NSURLSessionDataTask *)commentsForSubmission:(VKSubmission *)submission searchOptions:(VKSearchOptions*)searchOptions completion:(VKListingCompletionBlock)completion {
     NSParameterAssert(submission);
     
     return [self commentsForSubmissionWithIdentifier:submission.submissionID withSubverse:submission.subverse searchOptions:searchOptions completion:completion];
 }
 
-- (NSURLSessionDataTask *)commentsForSubmissionWithIdentifier:(NSNumber *)submissionIdentifier withSubverse:(NSString*)subverse searchOptions:(VKSearchOptions*)searchOptions completion:(VKArrayCompletionBlock)completion {
+- (NSURLSessionDataTask *)commentsForSubmissionWithIdentifier:(NSNumber *)submissionIdentifier withSubverse:(NSString*)subverse searchOptions:(VKSearchOptions*)searchOptions completion:(VKListingCompletionBlock)completion {
     NSParameterAssert(submissionIdentifier);
     NSParameterAssert(subverse);
     

--- a/Classes/Networking/VKClient+Requests.m
+++ b/Classes/Networking/VKClient+Requests.m
@@ -22,7 +22,7 @@
     NSParameterAssert(path);
     
     return [self postPath:path parameters:parameters completion:^(NSHTTPURLResponse *response, id responseObject, NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(self.completionQueue, ^{
             if (completion)
             {
                 completion(error);
@@ -38,7 +38,7 @@
     [taskParameters addEntriesFromDictionary:parameters];
     
     return [self postPath:path parameters:parameters completion:^(NSHTTPURLResponse *response, id responseObject, NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(self.completionQueue, ^{
             if (!completion)
             {
                 return;
@@ -60,7 +60,7 @@
                         objects = [VKObjectBuilder objectFromJSON:response[@"data"]];
                     }
                     
-                    dispatch_async(dispatch_get_main_queue(), ^{
+                    dispatch_async(self.completionQueue, ^{
                         completion(objects, nil);
                     });
                 });
@@ -80,7 +80,7 @@
     [taskParameters addEntriesFromDictionary:parameters];
     
     return [self getPath:path parameters:parameters completion:^(NSHTTPURLResponse *response, id responseObject, NSError *error) {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(self.completionQueue, ^{
             if (!completion)
             {
                 return;
@@ -92,7 +92,7 @@
                     NSDictionary *response = responseObject;
                     id object = [VKObjectBuilder objectFromJSON:response[@"data"]];
                     
-                    dispatch_async(dispatch_get_main_queue(), ^{
+                    dispatch_async(self.completionQueue, ^{
                         completion(object, nil);
                     });
                 });
@@ -127,7 +127,7 @@
                 
                 NSArray *objects = [self objectsFromListingResponse:response];
                 
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(self.completionQueue, ^{
                     NSLog(@"PARAMETERS");
                     completion(objects, nil, nil);
                 });
@@ -160,7 +160,7 @@
                 
                 NSArray *objects = [self objectsFromListingResponse:response];
                 
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(self.completionQueue, ^{
                     completion(objects, searchOptions, nil);
                 });
             });
@@ -188,7 +188,7 @@
         
         if (responseObject)
         {
-            dispatch_async(dispatch_get_main_queue(), ^{
+            dispatch_async(self.completionQueue, ^{
                 completion(responseObject, nil);
             });
         }
@@ -223,7 +223,7 @@
                 
                 NSArray *objects = [self objectsFromListingResponse:response];
                 
-                dispatch_async(dispatch_get_main_queue(), ^{
+                dispatch_async(self.completionQueue, ^{
                     completion(objects, nil);
                 });
             });
@@ -276,7 +276,7 @@
 {
     if (![self isSignedIn])
     {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(self.completionQueue, ^{
             if (completion)
             {
                 completion(nil, nil, [VKClient unauthorizedError]);
@@ -293,7 +293,7 @@
 {
     if (![self isSignedIn])
     {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(self.completionQueue, ^{
             if (completion)
             {
                 completion(nil, nil, [VKClient unauthorizedError]);
@@ -310,7 +310,7 @@
 {
     if (![self isSignedIn])
     {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(self.completionQueue, ^{
             if (completion)
             {
                 completion(nil, nil, [VKClient unauthorizedError]);
@@ -342,12 +342,10 @@
         NSDictionary *headers = [((NSHTTPURLResponse *)response) allHeaderFields];
         MONUnusedParameter(headers);
         
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (completion)
-            {
-                completion((NSHTTPURLResponse *)response, responseObject, error);
-            }
-        });
+        if (completion)
+        {
+            completion((NSHTTPURLResponse *)response, responseObject, error);
+        }
     }];
     
     [task resume];

--- a/Classes/Networking/VKClient+Users.m
+++ b/Classes/Networking/VKClient+Users.m
@@ -23,7 +23,7 @@
     //TODO: CHECK API TO SEE IF IMPLEMENTED: http://fakevout.azurewebsites.net/api/help/api/get-api-v1-u-saved
     if (![self isSignedIn])
     {
-        dispatch_async(dispatch_get_main_queue(), ^{
+        dispatch_async(self.completionQueue, ^{
             if (completion)
             {
                 completion(nil, nil, [VKClient unauthorizedError]);


### PR DESCRIPTION
This change uses the AFURLSessionManager's completionQueue to call the completion blocks. That way if an app wants to change the default queue, they can. By default AFNetworking sets this to the main queue anyway. Before this change, VoatKit was overriding the AFNetworking threading behavior.